### PR TITLE
fix: enable direct MP3 URL downloads with proper headers

### DIFF
--- a/EchoInStone/capture/audio_downloader.py
+++ b/EchoInStone/capture/audio_downloader.py
@@ -1,6 +1,8 @@
 import os
 import shutil
 import logging
+import requests
+from urllib.parse import urlparse
 from pydub import AudioSegment
 from . import DownloaderInterface
 
@@ -18,28 +20,56 @@ class AudioDownloader(DownloaderInterface):
 
     def download(self, file_path: str) -> str:
         """
-        Copies an audio file from a local file path to the specified output path
-        and converts it to WAV format for compatibility with PyAnnote.
+        Downloads an audio file from a URL or copies from a local file path,
+        then converts it to WAV format for compatibility with PyAnnote.
 
         Args:
-            file_path (str): Local file path to copy the file from.
+            file_path (str): URL or local file path to download/copy the file from.
 
         Returns:
-            str: Absolute path to the copied and converted WAV file if successful, None otherwise.
+            str: Absolute path to the downloaded and converted WAV file if successful, None otherwise.
         """
         try:
             # Ensure the output directory exists
             os.makedirs(self.output_dir, exist_ok=True)
             logger.debug(f"Output directory created or already exists: {self.output_dir}")
 
-            # Get the file name from the file path
-            file_name = os.path.basename(file_path)
-            file_base, file_ext = os.path.splitext(file_name)
-            destination_path = os.path.join(self.output_dir, file_name)
-
-            # Copy the file to the destination path
-            shutil.copy2(file_path, destination_path)
-            logger.info(f"File copied to {destination_path}")
+            # Check if it's a URL or local file
+            parsed_url = urlparse(file_path)
+            is_url = bool(parsed_url.netloc)
+            
+            if is_url:
+                # Download from URL
+                logger.info(f"Downloading audio from URL: {file_path}")
+                headers = {
+                    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
+                }
+                response = requests.get(file_path, stream=True, headers=headers)
+                response.raise_for_status()
+                
+                # Get the file name from the URL
+                file_name = os.path.basename(parsed_url.path)
+                if not file_name:
+                    file_name = "downloaded_audio.mp3"
+                
+                file_base, file_ext = os.path.splitext(file_name)
+                destination_path = os.path.join(self.output_dir, file_name)
+                
+                # Save the downloaded file
+                with open(destination_path, 'wb') as f:
+                    for chunk in response.iter_content(chunk_size=8192):
+                        f.write(chunk)
+                logger.info(f"File downloaded to {destination_path}")
+            else:
+                # Copy from local file
+                logger.info(f"Copying local file: {file_path}")
+                file_name = os.path.basename(file_path)
+                file_base, file_ext = os.path.splitext(file_name)
+                destination_path = os.path.join(self.output_dir, file_name)
+                
+                # Copy the file to the destination path
+                shutil.copy2(file_path, destination_path)
+                logger.info(f"File copied to {destination_path}")
             
             # Always convert to WAV for PyAnnote compatibility
             audio = AudioSegment.from_file(destination_path)
@@ -50,22 +80,44 @@ class AudioDownloader(DownloaderInterface):
             # Return the absolute path to the WAV file
             return os.path.abspath(wav_file)
         except Exception as e:
-            logger.error(f"Error during file copy/conversion: {e}")
+            logger.error(f"Error during file download/copy/conversion: {e}")
             return None
 
     def validate_url(self, file_path: str) -> bool:
         """
-        Validates if a file path is valid and the file exists.
+        Validates if a file path or URL is valid.
 
         Args:
-            file_path (str): Local file path to validate.
+            file_path (str): Local file path or URL to validate.
 
         Returns:
-            bool: True if the file path is valid and the file exists, False otherwise.
+            bool: True if the file path/URL is valid, False otherwise.
         """
-        if os.path.isfile(file_path):
-            logger.debug(f"File path is valid: {file_path}")
-            return True
+        # Check if it's a URL
+        parsed_url = urlparse(file_path)
+        is_url = bool(parsed_url.netloc)
+        
+        if is_url:
+            # For URLs, just check if the URL format is valid
+            try:
+                headers = {
+                    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
+                }
+                response = requests.head(file_path, timeout=10, headers=headers)
+                if response.status_code == 200:
+                    logger.debug(f"URL is valid: {file_path}")
+                    return True
+                else:
+                    logger.warning(f"URL returned status {response.status_code}: {file_path}")
+                    return False
+            except Exception as e:
+                logger.warning(f"Invalid URL: {file_path} - {e}")
+                return False
         else:
-            logger.warning(f"Invalid file path: {file_path}")
-            return False
+            # For local files, check if the file exists
+            if os.path.isfile(file_path):
+                logger.debug(f"File path is valid: {file_path}")
+                return True
+            else:
+                logger.warning(f"Invalid file path: {file_path}")
+                return False

--- a/EchoInStone/capture/downloader_factory.py
+++ b/EchoInStone/capture/downloader_factory.py
@@ -1,3 +1,5 @@
+import os
+from urllib.parse import urlparse
 from .podcast_downloader import PodcastDownloader
 from .youtube_downloader import YouTubeDownloader
 from .audio_downloader import AudioDownloader
@@ -11,7 +13,15 @@ def get_downloader(url: str, output_dir: str) -> DownloaderInterface:
         return YouTubeDownloader(output_dir=output_dir)
     elif url.endswith(".xml"):
         return PodcastDownloader(output_dir=output_dir)
-    elif url.endswith(".mp3") or url.endswith(".wav"):
+    elif url.endswith(".mp3") or url.endswith(".wav") or url.endswith(".m4a") or url.endswith(".flac"):
+        return AudioDownloader(output_dir=output_dir)
+    elif os.path.isfile(url):  # Local file path
         return AudioDownloader(output_dir=output_dir)
     else:
-        raise ValueError("Unsupported URL format")
+        # Check if it's a valid URL format
+        parsed_url = urlparse(url)
+        if bool(parsed_url.netloc):
+            # It's a URL but doesn't match our specific patterns, try AudioDownloader
+            return AudioDownloader(output_dir=output_dir)
+        else:
+            raise ValueError("Unsupported URL format")

--- a/README.md
+++ b/README.md
@@ -98,12 +98,61 @@ poetry run python main.py <audio_input_url>
 
 ## Testing
 
-To run the tests, use the following command:
+EchoInStone includes comprehensive test coverage with both unit tests and BDD (Behavior-Driven Development) tests to ensure reliability and prevent regressions.
+
+### Run All Tests
+
+To run all tests (unit tests and BDD tests):
 ```bash
-poetry run pytest
+poetry run pytest tests/ features/ -v
 ```
 
-This command will execute all the tests, including BDD tests, to ensure the functionality of the application.
+### Run Tests by Type
+
+**Unit Tests Only** (technical implementation tests):
+```bash
+poetry run pytest tests/ -v
+```
+
+**BDD Tests Only** (behavioral scenarios):
+```bash
+poetry run pytest features/ -v
+```
+
+### Test Coverage
+
+To generate a coverage report:
+```bash
+poetry run pytest tests/ features/ --cov=EchoInStone --cov-report html
+```
+
+The coverage report will be generated in the `htmlcov/` directory.
+
+### Test Structure
+
+- **`tests/`**: Unit tests that verify individual components and functions
+  - `test_audio_downloader.py`: Tests for URL/file downloading functionality
+  - `test_downloader_factory.py`: Tests for downloader selection logic
+  - `test_integration.py`: Integration tests for complete workflows
+
+- **`features/`**: BDD tests that describe user-facing behavior
+  - `downloader.feature`: Downloader selection scenarios
+  - `audio_download.feature`: Audio download functionality scenarios
+  - `successful_download.feature`: Download success scenarios
+  - `invalid_url.feature`: Error handling scenarios
+  - `transcription_output.feature`: Transcription output validation
+
+### Test Examples
+
+The test suite covers various scenarios including:
+- YouTube video downloads
+- Podcast RSS feed processing
+- Direct MP3/audio file URLs (including RFI radio content)
+- Local file processing
+- Network error handling
+- Header authentication for restricted URLs
+
+All tests are designed to prevent regressions and ensure that the audio download functionality works correctly across different input types.
 
 ## Configuration
 

--- a/features/audio_download.feature
+++ b/features/audio_download.feature
@@ -1,0 +1,38 @@
+Feature: Audio Download Functionality
+  As a user
+  I want to download audio files from URLs
+  So that I can process remote audio content
+
+  Scenario: Download audio from direct MP3 URL
+    Given I have a direct MP3 URL
+    When I download the audio file
+    Then the file should be downloaded successfully
+    And the file should be converted to WAV format
+
+  Scenario: Download audio from URL with authentication headers
+    Given I have an MP3 URL that requires specific headers
+    When I download the audio file with proper headers
+    Then the download should succeed with correct User-Agent
+    And the file should be saved in the output directory
+
+  Scenario: Handle network error during download
+    Given I have an MP3 URL that is unreachable
+    When I attempt to download the audio file
+    Then the download should fail gracefully
+    And an appropriate error should be logged
+
+  Scenario: Download local audio file
+    Given I have a local audio file path
+    When I copy the local audio file
+    Then the file should be copied successfully
+    And the file should be converted to WAV format
+
+  Scenario: Validate accessible URL
+    Given I have a valid audio URL
+    When I validate the URL
+    Then the validation should pass
+
+  Scenario: Validate inaccessible URL
+    Given I have an invalid audio URL
+    When I validate the URL
+    Then the validation should fail

--- a/features/downloader.feature
+++ b/features/downloader.feature
@@ -17,3 +17,18 @@ Feature: Downloader Selection
     Given the URL is an MP3 URL
     When the downloader is selected
     Then the Audio downloader should be returned
+
+  Scenario: Select Audio downloader for RFI URL
+    Given the URL is an RFI MP3 URL
+    When the downloader is selected
+    Then the Audio downloader should be returned
+
+  Scenario: Select Audio downloader for generic audio URL
+    Given the URL is a generic audio URL
+    When the downloader is selected
+    Then the Audio downloader should be returned
+
+  Scenario: Select Audio downloader for local file
+    Given the URL is a local audio file path
+    When the downloader is selected
+    Then the Audio downloader should be returned

--- a/features/steps/test_audio_download_bdd.py
+++ b/features/steps/test_audio_download_bdd.py
@@ -1,0 +1,215 @@
+import os
+import tempfile
+import shutil
+from unittest.mock import patch, MagicMock
+from pytest_bdd import scenarios, given, when, then
+from EchoInStone.capture.audio_downloader import AudioDownloader
+
+# Load scenarios from the feature file
+scenarios('../audio_download.feature')
+
+# Shared variables
+downloader = None
+url = ""
+result = None
+temp_dir = ""
+local_file_path = ""
+
+
+@given('I have a direct MP3 URL')
+def direct_mp3_url():
+    global url, downloader, temp_dir
+    temp_dir = tempfile.mkdtemp()
+    url = 'https://example.com/test.mp3'
+    downloader = AudioDownloader(output_dir=temp_dir)
+
+
+@given('I have an MP3 URL that requires specific headers')
+def mp3_url_with_headers():
+    global url, downloader, temp_dir
+    temp_dir = tempfile.mkdtemp()
+    url = 'https://aod-rfi.akamaized.net/rfi/francais/audio/modules/actu/202505/RADIO_FOOT_30-05-25_-_PSG_Reims.mp3'
+    downloader = AudioDownloader(output_dir=temp_dir)
+
+
+@given('I have an MP3 URL that is unreachable')
+def unreachable_mp3_url():
+    global url, downloader, temp_dir
+    temp_dir = tempfile.mkdtemp()
+    url = 'https://nonexistent-domain-12345.com/test.mp3'
+    downloader = AudioDownloader(output_dir=temp_dir)
+
+
+@given('I have a local audio file path')
+def local_audio_file():
+    global local_file_path, downloader, temp_dir
+    temp_dir = tempfile.mkdtemp()
+    
+    # Create a source file in a different directory
+    source_dir = tempfile.mkdtemp()
+    local_file_path = os.path.join(source_dir, 'test_audio.mp3')
+    with open(local_file_path, 'wb') as f:
+        f.write(b'fake audio content')
+    
+    downloader = AudioDownloader(output_dir=temp_dir)
+
+
+@given('I have a valid audio URL')
+def valid_audio_url():
+    global url, downloader, temp_dir
+    temp_dir = tempfile.mkdtemp()
+    url = 'https://example.com/valid.mp3'
+    downloader = AudioDownloader(output_dir=temp_dir)
+
+
+@given('I have an invalid audio URL')
+def invalid_audio_url():
+    global url, downloader, temp_dir
+    temp_dir = tempfile.mkdtemp()
+    url = 'https://nonexistent-domain-99999.com/invalid.mp3'
+    downloader = AudioDownloader(output_dir=temp_dir)
+
+
+@when('I download the audio file')
+def download_audio_file():
+    global result
+    with patch('EchoInStone.capture.audio_downloader.requests') as mock_requests, \
+         patch('EchoInStone.capture.audio_downloader.AudioSegment') as mock_audio:
+        
+        # Setup successful response
+        mock_response = MagicMock()
+        mock_response.iter_content.return_value = [b'fake', b'audio', b'data']
+        mock_response.raise_for_status.return_value = None
+        mock_requests.get.return_value = mock_response
+        
+        # Setup audio conversion
+        mock_audio_instance = MagicMock()
+        mock_audio.from_file.return_value = mock_audio_instance
+        
+        with patch('builtins.open', create=True) as mock_open:
+            result = downloader.download(url)
+
+
+@when('I download the audio file with proper headers')
+def download_with_headers():
+    global result
+    with patch('EchoInStone.capture.audio_downloader.requests') as mock_requests, \
+         patch('EchoInStone.capture.audio_downloader.AudioSegment') as mock_audio:
+        
+        # Setup successful response
+        mock_response = MagicMock()
+        mock_response.iter_content.return_value = [b'fake', b'audio', b'data']
+        mock_response.raise_for_status.return_value = None
+        mock_requests.get.return_value = mock_response
+        
+        # Setup audio conversion
+        mock_audio_instance = MagicMock()
+        mock_audio.from_file.return_value = mock_audio_instance
+        
+        with patch('builtins.open', create=True) as mock_open:
+            result = downloader.download(url)
+            
+        # Store the mock for later verification
+        global mock_requests_global
+        mock_requests_global = mock_requests
+
+
+@when('I attempt to download the audio file')
+def attempt_download_unreachable():
+    global result
+    with patch('EchoInStone.capture.audio_downloader.requests') as mock_requests:
+        # Simulate network error
+        mock_requests.get.side_effect = Exception("Network unreachable")
+        result = downloader.download(url)
+
+
+@when('I copy the local audio file')
+def copy_local_file():
+    global result
+    with patch('EchoInStone.capture.audio_downloader.AudioSegment') as mock_audio:
+        # Setup audio conversion
+        mock_audio_instance = MagicMock()
+        mock_audio.from_file.return_value = mock_audio_instance
+        
+        result = downloader.download(local_file_path)
+
+
+@when('I validate the URL')
+def validate_url():
+    global result
+    if url.startswith('https://example.com/valid'):
+        # Mock successful validation
+        with patch('EchoInStone.capture.audio_downloader.requests') as mock_requests:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_requests.head.return_value = mock_response
+            result = downloader.validate_url(url)
+    else:
+        # Mock failed validation
+        with patch('EchoInStone.capture.audio_downloader.requests') as mock_requests:
+            mock_requests.head.side_effect = Exception("Network error")
+            result = downloader.validate_url(url)
+
+
+@then('the file should be downloaded successfully')
+def verify_download_success():
+    assert result is not None
+    assert result.endswith('.wav')
+
+
+@then('the file should be converted to WAV format')
+def verify_wav_conversion():
+    assert result.endswith('.wav')
+    assert os.path.isabs(result)
+
+
+@then('the download should succeed with correct User-Agent')
+def verify_user_agent():
+    # Verify that the request was made with proper User-Agent header
+    mock_requests_global.get.assert_called_once()
+    args, kwargs = mock_requests_global.get.call_args
+    assert 'headers' in kwargs
+    assert 'User-Agent' in kwargs['headers']
+    assert 'Mozilla' in kwargs['headers']['User-Agent']
+
+
+@then('the file should be saved in the output directory')
+def verify_output_directory():
+    assert result is not None
+    assert temp_dir in result
+
+
+@then('the download should fail gracefully')
+def verify_download_failure():
+    assert result is None
+
+
+@then('an appropriate error should be logged')
+def verify_error_logging():
+    # This would normally check logging output, but for this test
+    # we just verify the download returned None (handled gracefully)
+    assert result is None
+
+
+@then('the file should be copied successfully')
+def verify_copy_success():
+    assert result is not None
+    assert result.endswith('.wav')
+
+
+@then('the validation should pass')
+def verify_validation_success():
+    assert result is True
+
+
+@then('the validation should fail')
+def verify_validation_failure():
+    assert result is False
+
+
+def teardown_function():
+    """Clean up temporary directories after each test"""
+    global temp_dir
+    if temp_dir and os.path.exists(temp_dir):
+        shutil.rmtree(temp_dir)
+        temp_dir = ""

--- a/features/steps/test_downloader_bdd.py
+++ b/features/steps/test_downloader_bdd.py
@@ -31,6 +31,30 @@ def mp3_url():
     # Set the URL to a direct MP3 file URL for testing purposes.
     url = 'https://media.radiofrance-podcast.net/podcast09/25425-13.02.2025-ITEMA_24028677-2025C53905E0006-NET_MFC_D378B90D-D570-44E9-AB5A-F0CC63B05A14-21.mp3'
 
+@given('the URL is an RFI MP3 URL')
+def rfi_mp3_url():
+    global url
+    # Set the URL to the specific RFI MP3 URL that was causing issues.
+    url = 'https://aod-rfi.akamaized.net/rfi/francais/audio/modules/actu/202505/RADIO_FOOT_30-05-25_-_PSG_Reims.mp3'
+
+@given('the URL is a generic audio URL')
+def generic_audio_url():
+    global url
+    # Set the URL to a generic audio URL without specific file extension.
+    url = 'https://example.com/audio-stream'
+
+@given('the URL is a local audio file path')
+def local_audio_file_path():
+    global url
+    # Set the URL to a local file path for testing purposes.
+    import tempfile
+    import os
+    temp_dir = tempfile.mkdtemp()
+    url = os.path.join(temp_dir, 'test_audio.mp3')
+    # Create the file so it exists for validation
+    with open(url, 'w') as f:
+        f.write('test')
+
 @when('the downloader is selected')
 def select_downloader():
     global downloader

--- a/tests/test_audio_downloader.py
+++ b/tests/test_audio_downloader.py
@@ -1,0 +1,155 @@
+import pytest
+import os
+import tempfile
+import shutil
+from unittest.mock import patch, MagicMock, mock_open
+from EchoInStone.capture.audio_downloader import AudioDownloader
+
+
+class TestAudioDownloader:
+    
+    def setup_method(self):
+        """Setup test environment before each test"""
+        self.temp_dir = tempfile.mkdtemp()
+        self.downloader = AudioDownloader(output_dir=self.temp_dir)
+    
+    def teardown_method(self):
+        """Cleanup test environment after each test"""
+        if os.path.exists(self.temp_dir):
+            shutil.rmtree(self.temp_dir)
+    
+    def test_local_file_copy_and_conversion(self):
+        """Test copying and converting a local audio file"""
+        # Create a temporary test file in a different directory to avoid same-file error
+        source_dir = tempfile.mkdtemp()
+        test_file = os.path.join(source_dir, "test_input.mp3")
+        with open(test_file, 'wb') as f:
+            f.write(b'fake mp3 content')
+        
+        try:
+            # Mock AudioSegment to avoid actual audio processing
+            with patch('EchoInStone.capture.audio_downloader.AudioSegment') as mock_audio:
+                mock_audio_instance = MagicMock()
+                mock_audio.from_file.return_value = mock_audio_instance
+                
+                result = self.downloader.download(test_file)
+                
+                # Verify the file was processed
+                assert result is not None
+                assert result.endswith('.wav')
+                assert os.path.isabs(result)
+                
+                # Verify AudioSegment was called correctly
+                mock_audio.from_file.assert_called_once()
+                mock_audio_instance.export.assert_called_once()
+        finally:
+            # Clean up source directory
+            if os.path.exists(source_dir):
+                shutil.rmtree(source_dir)
+    
+    @patch('EchoInStone.capture.audio_downloader.requests')
+    @patch('EchoInStone.capture.audio_downloader.AudioSegment')
+    def test_url_download_and_conversion(self, mock_audio, mock_requests):
+        """Test downloading and converting an audio file from URL"""
+        # Setup mocks
+        mock_response = MagicMock()
+        mock_response.iter_content.return_value = [b'fake', b'mp3', b'content']
+        mock_response.raise_for_status.return_value = None
+        mock_requests.get.return_value = mock_response
+        
+        mock_audio_instance = MagicMock()
+        mock_audio.from_file.return_value = mock_audio_instance
+        
+        test_url = "https://example.com/test.mp3"
+        
+        # Mock file writing
+        with patch('builtins.open', mock_open()) as mock_file:
+            result = self.downloader.download(test_url)
+            
+            # Verify URL was requested with proper headers
+            mock_requests.get.assert_called_once()
+            args, kwargs = mock_requests.get.call_args
+            assert args[0] == test_url
+            assert kwargs['stream'] == True
+            assert 'User-Agent' in kwargs['headers']
+            
+            # Verify file was written
+            mock_file.assert_called()
+            
+            # Verify audio conversion
+            mock_audio.from_file.assert_called_once()
+            mock_audio_instance.export.assert_called_once()
+            
+            # Verify result
+            assert result is not None
+            assert result.endswith('.wav')
+    
+    @patch('EchoInStone.capture.audio_downloader.requests')
+    def test_url_download_with_request_error(self, mock_requests):
+        """Test handling of HTTP errors during URL download"""
+        # Setup mock to raise an exception
+        mock_requests.get.side_effect = Exception("Network error")
+        
+        test_url = "https://example.com/test.mp3"
+        result = self.downloader.download(test_url)
+        
+        # Verify error handling
+        assert result is None
+    
+    def test_validate_url_local_file_exists(self):
+        """Test validation of existing local file"""
+        # Create a test file
+        test_file = os.path.join(self.temp_dir, "test.mp3")
+        with open(test_file, 'w') as f:
+            f.write('test')
+        
+        result = self.downloader.validate_url(test_file)
+        assert result == True
+    
+    def test_validate_url_local_file_not_exists(self):
+        """Test validation of non-existing local file"""
+        test_file = os.path.join(self.temp_dir, "nonexistent.mp3")
+        
+        result = self.downloader.validate_url(test_file)
+        assert result == False
+    
+    @patch('EchoInStone.capture.audio_downloader.requests')
+    def test_validate_url_valid_http_url(self, mock_requests):
+        """Test validation of valid HTTP URL"""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_requests.head.return_value = mock_response
+        
+        test_url = "https://example.com/test.mp3"
+        result = self.downloader.validate_url(test_url)
+        
+        # Verify request was made with proper headers
+        mock_requests.head.assert_called_once()
+        args, kwargs = mock_requests.head.call_args
+        assert args[0] == test_url
+        assert 'User-Agent' in kwargs['headers']
+        assert kwargs['timeout'] == 10
+        
+        assert result == True
+    
+    @patch('EchoInStone.capture.audio_downloader.requests')
+    def test_validate_url_invalid_http_url(self, mock_requests):
+        """Test validation of invalid HTTP URL"""
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_requests.head.return_value = mock_response
+        
+        test_url = "https://example.com/nonexistent.mp3"
+        result = self.downloader.validate_url(test_url)
+        
+        assert result == False
+    
+    @patch('EchoInStone.capture.audio_downloader.requests')
+    def test_validate_url_network_error(self, mock_requests):
+        """Test validation with network error"""
+        mock_requests.head.side_effect = Exception("Network error")
+        
+        test_url = "https://example.com/test.mp3"
+        result = self.downloader.validate_url(test_url)
+        
+        assert result == False

--- a/tests/test_downloader_factory.py
+++ b/tests/test_downloader_factory.py
@@ -1,0 +1,95 @@
+import pytest
+import tempfile
+import os
+from EchoInStone.capture.downloader_factory import get_downloader
+from EchoInStone.capture.youtube_downloader import YouTubeDownloader
+from EchoInStone.capture.podcast_downloader import PodcastDownloader
+from EchoInStone.capture.audio_downloader import AudioDownloader
+
+
+class TestDownloaderFactory:
+    
+    def setup_method(self):
+        """Setup test environment before each test"""
+        self.temp_dir = tempfile.mkdtemp()
+    
+    def test_youtube_url_returns_youtube_downloader(self):
+        """Test that YouTube URLs return YouTubeDownloader"""
+        youtube_urls = [
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            "https://youtu.be/dQw4w9WgXcQ",
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=10s"
+        ]
+        
+        for url in youtube_urls:
+            downloader = get_downloader(url, self.temp_dir)
+            assert isinstance(downloader, YouTubeDownloader)
+    
+    def test_podcast_url_returns_podcast_downloader(self):
+        """Test that podcast XML URLs return PodcastDownloader"""
+        podcast_urls = [
+            "https://feeds.npr.org/510289/podcast.xml",
+            "https://example.com/podcast.xml",
+            "http://feeds.feedburner.com/example.xml"
+        ]
+        
+        for url in podcast_urls:
+            downloader = get_downloader(url, self.temp_dir)
+            assert isinstance(downloader, PodcastDownloader)
+    
+    def test_audio_file_url_returns_audio_downloader(self):
+        """Test that direct audio file URLs return AudioDownloader"""
+        audio_urls = [
+            "https://example.com/audio.mp3",
+            "https://example.com/audio.wav", 
+            "https://example.com/audio.m4a",
+            "https://example.com/audio.flac",
+            "https://aod-rfi.akamaized.net/rfi/francais/audio/modules/actu/202505/RADIO_FOOT_30-05-25_-_PSG_Reims.mp3"
+        ]
+        
+        for url in audio_urls:
+            downloader = get_downloader(url, self.temp_dir)
+            assert isinstance(downloader, AudioDownloader)
+    
+    def test_local_file_path_returns_audio_downloader(self):
+        """Test that local file paths return AudioDownloader"""
+        # Create a temporary test file
+        test_file = os.path.join(self.temp_dir, "test.mp3")
+        with open(test_file, 'w') as f:
+            f.write('test')
+        
+        downloader = get_downloader(test_file, self.temp_dir)
+        assert isinstance(downloader, AudioDownloader)
+    
+    def test_generic_url_returns_audio_downloader(self):
+        """Test that generic URLs (not YouTube or XML) return AudioDownloader"""
+        generic_urls = [
+            "https://example.com/some-audio-file",
+            "http://radio.example.com/live-stream",
+            "https://media.example.com/content"
+        ]
+        
+        for url in generic_urls:
+            downloader = get_downloader(url, self.temp_dir)
+            assert isinstance(downloader, AudioDownloader)
+    
+    def test_unsupported_format_raises_error(self):
+        """Test that unsupported formats raise ValueError"""
+        # Only test cases that should actually raise errors
+        # Note: The factory now handles generic URLs with AudioDownloader
+        unsupported_urls = [
+            "not-a-url-and-not-a-file",
+            "completely/invalid/format"
+        ]
+        
+        for url in unsupported_urls:
+            with pytest.raises(ValueError, match="Unsupported URL format"):
+                get_downloader(url, self.temp_dir)
+    
+    def test_downloader_output_dir_is_set_correctly(self):
+        """Test that the output directory is correctly passed to downloaders"""
+        test_url = "https://example.com/test.mp3"
+        expected_output_dir = "/custom/output/dir"
+        
+        downloader = get_downloader(test_url, expected_output_dir)
+        assert downloader.output_dir == expected_output_dir

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,73 @@
+import pytest
+import os
+import tempfile
+import shutil
+from unittest.mock import patch, MagicMock
+from EchoInStone.capture.downloader_factory import get_downloader
+from EchoInStone.capture.audio_downloader import AudioDownloader
+
+
+class TestIntegration:
+    """Integration tests for the audio download functionality"""
+    
+    def setup_method(self):
+        """Setup test environment before each test"""
+        self.temp_dir = tempfile.mkdtemp()
+    
+    def teardown_method(self):
+        """Cleanup test environment after each test"""
+        if os.path.exists(self.temp_dir):
+            shutil.rmtree(self.temp_dir)
+    
+    def test_rfi_mp3_url_uses_audio_downloader(self):
+        """Test that the specific RFI MP3 URL that was failing uses AudioDownloader"""
+        rfi_url = "https://aod-rfi.akamaized.net/rfi/francais/audio/modules/actu/202505/RADIO_FOOT_30-05-25_-_PSG_Reims.mp3"
+        
+        downloader = get_downloader(rfi_url, self.temp_dir)
+        assert isinstance(downloader, AudioDownloader)
+    
+    @patch('EchoInStone.capture.audio_downloader.requests')
+    @patch('EchoInStone.capture.audio_downloader.AudioSegment')
+    def test_rfi_mp3_url_download_process(self, mock_audio, mock_requests):
+        """Test that the RFI MP3 URL follows the correct download process"""
+        rfi_url = "https://aod-rfi.akamaized.net/rfi/francais/audio/modules/actu/202505/RADIO_FOOT_30-05-25_-_PSG_Reims.mp3"
+        
+        # Setup mocks
+        mock_response = MagicMock()
+        mock_response.iter_content.return_value = [b'fake', b'mp3', b'content']
+        mock_response.raise_for_status.return_value = None
+        mock_requests.get.return_value = mock_response
+        
+        mock_audio_instance = MagicMock()
+        mock_audio.from_file.return_value = mock_audio_instance
+        
+        # Get downloader and test download
+        downloader = get_downloader(rfi_url, self.temp_dir)
+        
+        # Mock file writing
+        with patch('builtins.open') as mock_file:
+            result = downloader.download(rfi_url)
+            
+            # Verify URL was requested with proper headers
+            mock_requests.get.assert_called_once()
+            args, kwargs = mock_requests.get.call_args
+            assert args[0] == rfi_url
+            assert kwargs['stream'] == True
+            assert 'User-Agent' in kwargs['headers']
+            
+            # Verify the result
+            assert result is not None
+            assert result.endswith('.wav')
+    
+    def test_various_mp3_urls_use_audio_downloader(self):
+        """Test that various MP3 URLs all use AudioDownloader"""
+        mp3_urls = [
+            "https://example.com/audio.mp3",
+            "https://media.radiofrance-podcast.net/podcast09/test.mp3",
+            "https://aod-rfi.akamaized.net/rfi/francais/audio/modules/actu/202505/RADIO_FOOT_30-05-25_-_PSG_Reims.mp3",
+            "http://example.com/folder/audio.mp3"
+        ]
+        
+        for url in mp3_urls:
+            downloader = get_downloader(url, self.temp_dir)
+            assert isinstance(downloader, AudioDownloader), f"Failed for URL: {url}"


### PR DESCRIPTION
- Modified AudioDownloader to handle both local files and URLs
- Added HTTP headers including User-Agent for restricted URLs
- Updated downloader factory logic to properly route URLs vs local files
- Added comprehensive unit tests for URL download functionality
- Added BDD tests for audio download scenarios and error handling
- Updated README with detailed testing documentation

Fixes issue where MP3 URLs were incorrectly treated as local files, causing "No such file or directory" errors. Now supports direct downloads from URLs like RFI radio content.