### PR TITLE
fix(capture): podcast downloader return path, sanitization, and WAV conversion

### DIFF
--- a/EchoInStone/capture/podcast_downloader.py
+++ b/EchoInStone/capture/podcast_downloader.py
@@ -1,64 +1,95 @@
+import os
+import re
+import logging
+
 import feedparser
 import requests
-import logging
+from pydub import AudioSegment
+
 from ..capture import DownloaderInterface
-import re
 
 logger = logging.getLogger(__name__)
 
+
 class PodcastDownloader(DownloaderInterface):
-    def __init__(self, output_dir='data/podcasts'):
-        """
-        Initializes the PodcastDownloader with a specified output directory.
+    def __init__(self, output_dir: str = "data/podcasts") -> None:
+        """Initialize the PodcastDownloader.
 
         Args:
-            output_dir (str): The directory where downloaded podcast episodes will be saved.
+            output_dir: Directory where downloaded podcast episodes will be saved.
         """
         self.output_dir = output_dir
 
-    def download(self, url: str) -> bool:
-        """
-        Downloads a podcast episode from an RSS feed URL.
+    @staticmethod
+    def _safe_title(title: str) -> str:
+        """Strip unicode whitespace and unsafe filesystem chars from a title."""
+        collapsed = re.sub(r"\s+", "_", title)
+        cleaned = re.sub(r"[^\w-]", "", collapsed)
+        return cleaned or "episode"
+
+    def download(self, url: str) -> str | None:
+        """Download the first enclosure of a podcast RSS feed and convert to WAV.
+
+        Podcast hosts frequently serve M4A/AAC behind a `.mp3` URL, so the raw
+        bytes are decoded via pydub/ffmpeg and re-encoded to WAV — the format
+        consumed uniformly by the transcription and diarization pipelines.
 
         Args:
-            url (str): RSS feed URL containing the podcast episodes.
+            url: RSS feed URL containing the podcast episodes.
 
         Returns:
-            bool: True if the download was successful, False otherwise.
+            Absolute path to the saved WAV file on success, None otherwise.
         """
         try:
             feed = feedparser.parse(url)
             logger.debug(f"Parsed RSS feed with {len(feed.entries)} entries.")
             for entry in feed.entries:
                 for link in entry.links:
-                    if link.rel == 'enclosure':
-                        audio_url = link.href
-                        response = requests.get(audio_url)
-                        audio_file = f"{self.output_dir}/{entry.title}.mp3"
-                        safe_audio_file = re.sub(r'[^\w\s-]', '', audio_file).replace(' ', '_')
-                        with open(safe_audio_file, 'wb') as f:
-                            f.write(response.content)
-                        logger.info(f"Podcast downloaded: {safe_audio_file}")
-                        return True
+                    if link.rel != "enclosure":
+                        continue
+
+                    audio_url = link.href
+                    os.makedirs(self.output_dir, exist_ok=True)
+
+                    safe_title = self._safe_title(entry.title)
+                    raw_destination = os.path.join(self.output_dir, f"{safe_title}.audio")
+                    wav_destination = os.path.join(self.output_dir, f"{safe_title}.wav")
+
+                    response = requests.get(audio_url, stream=True, timeout=60)
+                    response.raise_for_status()
+                    with open(raw_destination, "wb") as f:
+                        for chunk in response.iter_content(chunk_size=64 * 1024):
+                            if chunk:
+                                f.write(chunk)
+
+                    audio = AudioSegment.from_file(raw_destination)
+                    audio.export(wav_destination, format="wav")
+                    try:
+                        os.remove(raw_destination)
+                    except OSError:
+                        pass
+
+                    logger.info(f"Podcast downloaded and converted: {wav_destination}")
+                    return os.path.abspath(wav_destination)
+
             logger.warning("Episode not found.")
-            return False
+            return None
         except Exception as e:
             logger.error(f"Error during download: {e}")
-            return False
+            return None
 
     def validate_url(self, url: str) -> bool:
-        """
-        Validates if a URL is a valid RSS feed URL for podcasts.
+        """Validate that a URL parses as a well-formed RSS feed.
 
         Args:
-            url (str): URL to validate.
+            url: URL to validate.
 
         Returns:
-            bool: True if the URL is a valid RSS feed URL, False otherwise.
+            True if the URL parses without errors, False otherwise.
         """
         try:
             feed = feedparser.parse(url)
-            if feed.bozo == 0:  # 0 indicates no error in parsing
+            if feed.bozo == 0:
                 logger.debug(f"Valid RSS feed URL: {url}")
                 return True
             logger.warning(f"Invalid RSS feed URL: {url}")

--- a/tests/test_podcast_downloader.py
+++ b/tests/test_podcast_downloader.py
@@ -1,0 +1,207 @@
+"""Unit tests for PodcastDownloader.
+
+Covers two regressions observed when running the real pipeline:
+1. download() returned True instead of the file path, so transcribe()/diarize()
+   received a bool.
+2. The sanitization regex stripped path separators, so the file was written
+   in the CWD instead of inside output_dir.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from EchoInStone.capture.podcast_downloader import PodcastDownloader
+
+
+def _fake_feed(title: str, audio_url: str = "https://example.com/episode.mp3") -> MagicMock:
+    enclosure = MagicMock()
+    enclosure.rel = "enclosure"
+    enclosure.href = audio_url
+    entry = MagicMock()
+    entry.title = title
+    entry.links = [enclosure]
+    feed = MagicMock()
+    feed.entries = [entry]
+    return feed
+
+
+@pytest.fixture
+def temp_output_dir() -> str:
+    with tempfile.TemporaryDirectory() as d:
+        yield d
+
+
+@pytest.fixture(autouse=True)
+def _stub_audio_segment():
+    """Mock pydub by default so synthetic bytes don't crash ffmpeg.
+
+    Tests that need real conversion behavior can override via their own patch.
+    """
+    fake_segment = MagicMock()
+
+    def fake_export(out_path: str, format: str) -> None:  # noqa: A002
+        with open(out_path, "wb") as f:
+            f.write(b"RIFF....WAVE")
+
+    fake_segment.export.side_effect = fake_export
+    with patch(
+        "EchoInStone.capture.podcast_downloader.AudioSegment.from_file",
+        return_value=fake_segment,
+    ):
+        yield
+
+
+def test_download_returns_path_to_saved_file(temp_output_dir: str) -> None:
+    downloader = PodcastDownloader(output_dir=temp_output_dir)
+
+    response = MagicMock()
+    response.content = b"\x00\x01\x02fake-mp3-bytes"
+    response.raise_for_status = MagicMock()
+
+    with patch(
+        "EchoInStone.capture.podcast_downloader.feedparser.parse",
+        return_value=_fake_feed(title="Hello World"),
+    ), patch(
+        "EchoInStone.capture.podcast_downloader.requests.get",
+        return_value=response,
+    ):
+        result = downloader.download("https://example.com/feed.xml")
+
+    assert isinstance(result, str), f"Expected path string, got {type(result).__name__}"
+    assert os.path.isfile(result), f"Expected file to exist at {result}"
+
+
+def test_download_writes_inside_output_dir(temp_output_dir: str) -> None:
+    """The output_dir separator must survive sanitization."""
+    downloader = PodcastDownloader(output_dir=temp_output_dir)
+
+    response = MagicMock()
+    response.content = b"data"
+    response.raise_for_status = MagicMock()
+
+    with patch(
+        "EchoInStone.capture.podcast_downloader.feedparser.parse",
+        return_value=_fake_feed(title="Episode With Spaces"),
+    ), patch(
+        "EchoInStone.capture.podcast_downloader.requests.get",
+        return_value=response,
+    ):
+        result = downloader.download("https://example.com/feed.xml")
+
+    parent = Path(result).resolve().parent
+    expected_parent = Path(temp_output_dir).resolve()
+    assert parent == expected_parent, (
+        f"File written outside output_dir: parent={parent}, expected={expected_parent}"
+    )
+
+
+def test_download_sanitizes_unsafe_chars_in_title(temp_output_dir: str) -> None:
+    downloader = PodcastDownloader(output_dir=temp_output_dir)
+
+    response = MagicMock()
+    response.content = b"data"
+    response.raise_for_status = MagicMock()
+
+    with patch(
+        "EchoInStone.capture.podcast_downloader.feedparser.parse",
+        return_value=_fake_feed(title="Euphoria saison 3 (fiction nulle?)"),
+    ), patch(
+        "EchoInStone.capture.podcast_downloader.requests.get",
+        return_value=response,
+    ):
+        result = downloader.download("https://example.com/feed.xml")
+
+    name = Path(result).name
+    for forbidden in ["(", ")", "?", " "]:
+        assert forbidden not in name, f"Unsanitized {forbidden!r} in {name!r}"
+
+
+def test_download_replaces_unicode_whitespace(temp_output_dir: str) -> None:
+    """Non-breaking spaces (NBSP) and other unicode whitespace must not survive."""
+    downloader = PodcastDownloader(output_dir=temp_output_dir)
+
+    response = MagicMock()
+    response.content = b"data"
+    response.raise_for_status = MagicMock()
+
+    title_with_nbsp = "Euphoria saison 3 _ putes partout"
+    with patch(
+        "EchoInStone.capture.podcast_downloader.feedparser.parse",
+        return_value=_fake_feed(title=title_with_nbsp),
+    ), patch(
+        "EchoInStone.capture.podcast_downloader.requests.get",
+        return_value=response,
+    ):
+        result = downloader.download("https://example.com/feed.xml")
+
+    name = Path(result).name
+    assert " " not in name, f"NBSP leaked into filename: {name!r}"
+    assert " " not in name, f"Plain space leaked into filename: {name!r}"
+
+
+def test_download_returns_wav_path(temp_output_dir: str) -> None:
+    """Pyannote/Whisper consume WAV uniformly; podcast hosts often serve M4A
+    behind .mp3 URLs. The downloader must convert before returning."""
+    downloader = PodcastDownloader(output_dir=temp_output_dir)
+
+    response = MagicMock()
+    response.content = b"fake-audio-bytes"
+    response.raise_for_status = MagicMock()
+
+    fake_segment = MagicMock()
+
+    def fake_export(out_path: str, format: str) -> None:  # noqa: A002 (mirrors pydub API)
+        with open(out_path, "wb") as f:
+            f.write(b"RIFF....WAVE")
+
+    fake_segment.export.side_effect = fake_export
+
+    with patch(
+        "EchoInStone.capture.podcast_downloader.feedparser.parse",
+        return_value=_fake_feed(title="Some Episode"),
+    ), patch(
+        "EchoInStone.capture.podcast_downloader.requests.get",
+        return_value=response,
+    ), patch(
+        "EchoInStone.capture.podcast_downloader.AudioSegment.from_file",
+        return_value=fake_segment,
+    ):
+        result = downloader.download("https://example.com/feed.xml")
+
+    assert result is not None
+    assert result.endswith(".wav"), f"Expected .wav suffix, got {result!r}"
+    assert os.path.isfile(result)
+
+
+def test_download_returns_none_when_no_enclosure() -> None:
+    downloader = PodcastDownloader(output_dir="unused")
+
+    feed = MagicMock()
+    feed.entries = []
+
+    with patch(
+        "EchoInStone.capture.podcast_downloader.feedparser.parse",
+        return_value=feed,
+    ):
+        result = downloader.download("https://example.com/feed.xml")
+
+    assert result is None
+
+
+def test_download_returns_none_on_request_error(temp_output_dir: str) -> None:
+    downloader = PodcastDownloader(output_dir=temp_output_dir)
+
+    with patch(
+        "EchoInStone.capture.podcast_downloader.feedparser.parse",
+        return_value=_fake_feed(title="Boom"),
+    ), patch(
+        "EchoInStone.capture.podcast_downloader.requests.get",
+        side_effect=RuntimeError("network down"),
+    ):
+        result = downloader.download("https://example.com/feed.xml")
+
+    assert result is None


### PR DESCRIPTION
## Summary

Three bugs prevented `poetry run python main.py <podcast.xml>` from working end-to-end:

1. `PodcastDownloader.download()` returned `True`/`False` instead of a path. The orchestrator then passed a `bool` to `WhisperAudioTranscriber.transcribe()` / `PyannoteDiarizer.diarize()`, both of which crashed, and `SpeakerAligner.align()` blew up on `'NoneType' object has no attribute 'itersegments'`.
2. The sanitization regex `[^\w\s-]` was applied to the full path (`output_dir/title.mp3`), so the `/` separator was stripped — episodes were written in the CWD as `resultsEuphoria_…mp3` instead of inside `results/`.
3. `\s` matched unicode whitespace (NBSP `U+00A0`) but `.replace(' ', '_')` only handled ASCII spaces. RSS titles containing NBSP (e.g. *Euphoria saison 3 _ putes partout*) produced filenames that downstream tools could not open.

A fourth surprise was uncovered in real testing: Radio France serves **M4A (AAC)** behind `.mp3` URLs. The transcriber and diarizer choke on the format mismatch.

## Fix

- `_safe_title()` helper: `\s+ → _` first, then strip everything outside `[\w-]` — handles NBSP and any other unicode whitespace.
- Sanitize the title only; build the destination via `os.path.join(self.output_dir, …)` so the separator survives.
- `os.makedirs(self.output_dir, exist_ok=True)` before writing.
- Stream the HTTP response in 64 KiB chunks (no `.content` blob).
- Convert the downloaded audio to WAV via `pydub`/`ffmpeg`, matching what `AudioDownloader` and `YouTubeDownloader` already do, so transcription and diarization receive a uniform format.
- Return the absolute WAV path on success, `None` on any failure (no more bool).

## Test plan

- [x] `tests/test_podcast_downloader.py` — 7 unit tests:
    - Returns a path string (not bool) and the file exists
    - File written inside `output_dir` (slash preserved)
    - ASCII unsafe chars stripped from title
    - NBSP and other unicode whitespace replaced with `_`
    - Returned path ends in `.wav`
    - Returns `None` when no enclosure found
    - Returns `None` on request error
- [x] Full suite: `pytest tests/ features/` → 39 passed (1 deselected — the pre-existing flaky Whisper assertion)
- [x] End-to-end with the 3 README examples on real URLs:
    - YouTube `plZRCMx_Jd8` → 4 segments, 4 speakers
    - Podcast RSS `rss_13957.xml` (France Inter) → 77 segments, 2 speakers
    - Direct MP3 (ITEMA) → 10 segments, 3 speakers